### PR TITLE
Address broken navigation and CSS/JS resource links on About page.

### DIFF
--- a/_includes/css.html
+++ b/_includes/css.html
@@ -8,17 +8,18 @@
         <!-- Core BootStrap CSS -->
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
         <!-- Material Design CSS -->
-        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/bootstrap-material-design.min.css">
+        <link rel="stylesheet" href="{{ '/static/css/bootstrap-material-design.min.css' | absolute_url }}">
 
         <!-- syntax highlighting CSS -->
-        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/syntax.css">
+        <link rel="stylesheet" href="{{ '/static/css/syntax.css' | absolute_url }}">
 
         <!-- Custom CSS -->        
-        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/thickbox.css">
-        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/main.css">
-        <link rel="stylesheet" href="{{ site.baseurl }}/static/css/projects.css">
+        <link rel="stylesheet" href="{{ '/static/css/thickbox.css' | absolute_url }}">
+        <link rel="stylesheet" href="{{ '/static/css/main.css' | absolute_url }}">
+        <link rel="stylesheet" href="{{ '/static/css/projects.css' | absolute_url }}">
+        
         <link href="https://fonts.googleapis.com/css?family=Open+Sans|Poiret+One" rel="stylesheet">
         <script type="text/javascript">
           //loadingImage is relative to project dir
-          var tb_pathToImage = "{{ site.baseurl }}/static/img/loadingAnimation.gif";
+          var tb_pathToImage = "{{ '/static/img/loadingAnimation.gif' | absolute_url }}";
         </script>

--- a/_includes/js.html
+++ b/_includes/js.html
@@ -3,9 +3,9 @@
 <script src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 {% if site.allowsearch ==  true %}
-<script src="{{ site.baseurl }}/static/js/super-search.js"></script>
+<script src="{{ '/static/js/super-search.js' | absolute_url }}"></script>
 {% endif %}
-<script src="{{ site.baseurl }}/static/js/thickbox-compressed.js"></script>
-<script src="{{ site.baseurl }}/static/js/material.min.js"></script>
-<script src="{{ site.baseurl }}/static/js/main.js"></script>
-<script src="{{ site.baseurl }}/static/js/projects.js"></script>
+<script src="{{ '/static/js/thickbox-compressed.js' | absolute_url }}"></script>
+<script src="{{ '/static/js/material.min.js' | absolute_url }}"></script>
+<script src="{{ '/static/js/main.js' | absolute_url }}"></script>
+<script src="{{ '/static/js/projects.js' | absolute_url }}"></script>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,17 +1,6 @@
 <ul class="list-separator nav navbar-nav well well-primary {{ page.layout }}">
 {% for i in site.data.urls %}
-	{% assign current = nil %}
-	{% assign pageurl = page.url | split:'/' | last %}
-	{% assign menuurl = i.url | split:'/' | last %}
-	{% assign linkurl = nil %}
-	{% if i.url contains '://' %}
-	{% assign linkurl = i.url %}
-	{% else %}
-	{% assign linkurl = i.url | prepend: site.baseurl %}
-	{% endif %}
-	{% assign target = i.target %}
-    {% unless target %} {% assign target = '_self' %} {% endunless %}
-	{% if pageurl == menuurl or page.layout == i.layout %} {% assign current = 'current-menu-item' %} {% endif %}
+	{% assign linkurl = i.url | absolute_url %}
 	<li class="col-lg-12 col-md-12 col-sm-4 col-xs-12 {{ current }} {{ pageurl }}"><a href="{{ linkurl }}" target="{{ target }}"><i class="fa {{ i.icon }}"></i> {{ i.text }}</a></li>
 {% endfor %}
 </ul>


### PR DESCRIPTION
Hey Jessi/Susan,

Was browsing the DataBytes Podcast website and noticed that the `About` page looked a little different than the index page. This PR contains some minor adjustments that should address the navigation and styling issues seen on that page.

**Proposed Changes**:
- Simplify the navigation link construction process to build links correctly on non-index pages.
- Adjust CSS/JS linking methods to fetch static resources properly.

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/6403614/56438656-b6602b00-62b1-11e9-9765-0bd6d47d8cd4.png"> | <img src="https://user-images.githubusercontent.com/6403614/56438671-bfe99300-62b1-11e9-8eb4-b3f359d544ea.png"> |